### PR TITLE
New Extractors: SuperVideo and Streamtape

### DIFF
--- a/mediaflow_proxy/extractors/factory.py
+++ b/mediaflow_proxy/extractors/factory.py
@@ -5,6 +5,10 @@ from mediaflow_proxy.extractors.doodstream import DoodStreamExtractor
 from mediaflow_proxy.extractors.livetv import LiveTVExtractor
 from mediaflow_proxy.extractors.mixdrop import MixdropExtractor
 from mediaflow_proxy.extractors.uqload import UqloadExtractor
+from mediaflow_proxy.extractors.streamtape import StreamtapeExtractor
+from mediaflow_proxy.extractors.supervideo import SupervideoExtractor
+
+
 
 
 class ExtractorFactory:
@@ -14,6 +18,8 @@ class ExtractorFactory:
         "Doodstream": DoodStreamExtractor,
         "Uqload": UqloadExtractor,
         "Mixdrop": MixdropExtractor,
+        "Streamtape": StreamtapeExtractor,
+        "Supervideo": SupervideoExtractor,
         "LiveTV": LiveTVExtractor,
     }
 

--- a/mediaflow_proxy/extractors/streamtape.py
+++ b/mediaflow_proxy/extractors/streamtape.py
@@ -1,0 +1,32 @@
+import re
+from typing import Dict, Any
+
+from mediaflow_proxy.extractors.base import BaseExtractor, ExtractorError
+
+
+class StreamtapeExtractor(BaseExtractor):
+    """Streamtape URL extractor."""
+
+    async def extract(self, url: str, **kwargs) -> Dict[str, Any]:
+        """Extract Streamtape URL."""
+        response = await self._make_request(url)
+
+        # Extract and decode URL
+        matches = re.findall(r"id=.*?(?=')", response.text)
+        if not matches:
+            raise ExtractorError("Failed to extract URL components")
+        final_url = next(
+            (
+                f"https://streamtape.com/get_video?{matches[i + 1]}"
+                for i in range(len(matches) - 1)
+                if matches[i] == matches[i + 1]
+            ),
+            None,
+        )
+
+        self.base_headers["referer"] = url
+        return {
+            "destination_url": final_url,
+            "request_headers": self.base_headers,
+            "mediaflow_endpoint": self.mediaflow_endpoint,
+        }

--- a/mediaflow_proxy/extractors/supervideo.py
+++ b/mediaflow_proxy/extractors/supervideo.py
@@ -1,0 +1,27 @@
+import re
+from typing import Dict, Any
+
+from mediaflow_proxy.extractors.base import BaseExtractor, ExtractorError
+
+
+class SupervideoExtractor(BaseExtractor):
+    """Supervideo URL extractor."""
+
+    async def extract(self, url: str, **kwargs) -> Dict[str, Any]:
+        """Extract Supervideo URL."""
+        response = await self._make_request(url)
+        # Extract and decode URL
+        s2 = re.search(r"\}\('(.+)',.+,'(.+)'\.split", response.text).group(2)
+        terms = s2.split("|")
+        hfs = next(terms[i] for i in range(terms.index("file"), len(terms)) if "hfs" in terms[i])
+        result = terms[terms.index("urlset") + 1 : terms.index("hls")]
+
+        base_url = f"https://{hfs}.serversicuro.cc/hls/"
+        final_url = base_url + ",".join(reversed(result)) + (".urlset/master.m3u8" if result else "")
+
+        self.base_headers["referer"] = url
+        return {
+            "destination_url": final_url,
+            "request_headers": self.base_headers,
+            "mediaflow_endpoint": self.mediaflow_endpoint,
+        }

--- a/mediaflow_proxy/schemas.py
+++ b/mediaflow_proxy/schemas.py
@@ -63,7 +63,7 @@ class MPDSegmentParams(GenericParams):
 
 
 class ExtractorURLParams(GenericParams):
-    host: Literal["Doodstream", "Mixdrop", "Uqload", "LiveTV"] = Field(
+    host: Literal["Doodstream", "Mixdrop", "Uqload", "Streamtape", "Supervideo", "LiveTV"] = Field(
         ..., description="The host to extract the URL from."
     )
     destination: str = Field(..., description="The URL of the stream.", alias="d")


### PR DESCRIPTION
# New Extractors
This PR adds two new extractors to Mediaflow-proxy:

- Streamtape: IP-Locked
- Supervideo: No limitations

Links for testing:
I have links for testing both of those extractors, DM me if you need them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for extracting URLs from Streamtape and Supervideo.
	- Introduced two new extractor classes: `StreamtapeExtractor` and `SupervideoExtractor`.

- **Bug Fixes**
	- Enhanced error handling in the URL extraction process for new hosts.

- **Documentation**
	- Updated the `ExtractorURLParams` to include new valid options for the `host` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->