### PR TITLE
Enhance m3u8 handling with on-the-fly processing and retries with configurable timeout

### DIFF
--- a/mediaflow_proxy/configs.py
+++ b/mediaflow_proxy/configs.py
@@ -23,6 +23,7 @@ class TransportConfig(BaseSettings):
     transport_routes: Dict[str, RouteConfig] = Field(
         default_factory=dict, description="Pattern-based route configuration"
     )
+    timeout: int = Field(30, description="Timeout for HTTP requests in seconds")
 
     def get_mounts(
         self, async_http: bool = True

--- a/mediaflow_proxy/handlers.py
+++ b/mediaflow_proxy/handlers.py
@@ -1,6 +1,6 @@
 import base64
 import logging
-from urllib.parse import urlparse
+from urllib.parse import urlparse, parse_qs
 
 import httpx
 from fastapi import Request, Response, HTTPException
@@ -74,31 +74,31 @@ async def handle_hls_stream_proxy(
         Union[Response, EnhancedStreamingResponse]: Either a processed m3u8 playlist or a streaming response.
     """
     client, streamer = await setup_client_and_streamer()
+    # Handle range requests
+    content_range = proxy_headers.request.get("range", "bytes=0-")
+    if "NaN" in content_range:
+        # Handle invalid range requests "bytes=NaN-NaN"
+        raise HTTPException(status_code=416, detail="Invalid Range Header")
+    proxy_headers.request.update({"range": content_range})
 
     try:
-        if urlparse(hls_params.destination).path.endswith((".m3u", ".m3u8")):
+        parsed_url = urlparse(hls_params.destination)
+        # Check if the URL is a valid m3u8 playlist or m3u file
+        if parsed_url.path.endswith((".m3u", ".m3u8", ".m3u_plus")) or parse_qs(parsed_url.query).get("type", [""])[
+            0
+        ] in ["m3u", "m3u8", "m3u_plus"]:
             return await fetch_and_process_m3u8(
                 streamer, hls_params.destination, proxy_headers, request, hls_params.key_url
             )
 
         # Create initial streaming response to check content type
         await streamer.create_streaming_response(hls_params.destination, proxy_headers.request)
+        response_headers = prepare_response_headers(streamer.response.headers, proxy_headers.response)
 
-        if "mpegurl" in streamer.response.headers.get("content-type", "").lower():
+        if "mpegurl" in response_headers.get("content-type", "").lower():
             return await fetch_and_process_m3u8(
                 streamer, hls_params.destination, proxy_headers, request, hls_params.key_url
             )
-
-        # Handle range requests
-        content_range = proxy_headers.request.get("range", "bytes=0-")
-        if "NaN" in content_range:
-            # Handle invalid range requests "bytes=NaN-NaN"
-            raise HTTPException(status_code=416, detail="Invalid Range Header")
-        proxy_headers.request.update({"range": content_range})
-
-        # Create new streaming response with updated headers
-        await streamer.create_streaming_response(hls_params.destination, proxy_headers.request)
-        response_headers = prepare_response_headers(streamer.response.headers, proxy_headers.response)
 
         return EnhancedStreamingResponse(
             streamer.stream_content(),
@@ -190,7 +190,7 @@ async def fetch_and_process_m3u8(
     streamer: Streamer, url: str, proxy_headers: ProxyRequestHeaders, request: Request, key_url: str = None
 ):
     """
-    Fetches and processes the m3u8 playlist, converting it to an HLS playlist.
+    Fetches and processes the m3u8 playlist on-the-fly, converting it to an HLS playlist.
 
     Args:
         streamer (Streamer): The HTTP client to use for streaming.
@@ -203,20 +203,28 @@ async def fetch_and_process_m3u8(
         Response: The HTTP response with the processed m3u8 playlist.
     """
     try:
-        content = await streamer.get_text(url, proxy_headers.request)
+        # Create streaming response if not already created
+        if not streamer.response:
+            await streamer.create_streaming_response(url, proxy_headers.request)
+
+        # Initialize processor and response headers
         processor = M3U8Processor(request, key_url)
-        processed_content = await processor.process_m3u8(content, str(streamer.response.url))
-        response_headers = {"Content-Disposition": "inline", "Accept-Ranges": "none"}
+        response_headers = {
+            "Content-Disposition": "inline",
+            "Accept-Ranges": "none",
+            "Content-Type": "application/vnd.apple.mpegurl",
+        }
         response_headers.update(proxy_headers.response)
-        return Response(
-            content=processed_content,
-            media_type="application/vnd.apple.mpegurl",
+
+        # Create streaming response with on-the-fly processing
+        return EnhancedStreamingResponse(
+            processor.process_m3u8_streaming(streamer.stream_content(), str(streamer.response.url)),
             headers=response_headers,
+            background=BackgroundTask(streamer.close),
         )
     except Exception as e:
-        return handle_exceptions(e)
-    finally:
         await streamer.close()
+        return handle_exceptions(e)
 
 
 async def handle_drm_key_data(key_id, key, drm_info):

--- a/mediaflow_proxy/utils/m3u8_processor.py
+++ b/mediaflow_proxy/utils/m3u8_processor.py
@@ -1,4 +1,6 @@
+import logging
 import re
+from typing import AsyncGenerator
 from urllib import parse
 
 from mediaflow_proxy.utils.crypto_utils import encryption_handler
@@ -41,6 +43,86 @@ class M3U8Processor:
             else:
                 processed_lines.append(line)
         return "\n".join(processed_lines)
+
+    async def process_m3u8_streaming(
+        self, content_iterator: AsyncGenerator[bytes, None], base_url: str
+    ) -> AsyncGenerator[str, None]:
+        """
+        Processes the m3u8 content on-the-fly, yielding processed lines as they are read.
+
+        Args:
+            content_iterator: An async iterator that yields chunks of the m3u8 content.
+            base_url (str): The base URL to resolve relative URLs.
+
+        Yields:
+            str: Processed lines of the m3u8 content.
+        """
+        buffer = b""  # Use bytes buffer instead of str
+
+        # Process the content chunk by chunk
+        async for chunk in content_iterator:
+            if isinstance(chunk, str):
+                chunk = chunk.encode("utf-8")
+
+            buffer += chunk
+
+            try:
+                # Try to decode the current buffer with error handling
+                decoded_buffer = buffer.decode("utf-8", errors="replace")
+                lines = decoded_buffer.split("\n")
+
+                # If we have at least one line and the buffer ends with newline,
+                # we process all lines including the last one
+                if len(lines) > 1:
+                    # Process all complete lines except the last one
+                    for line in lines[:-1]:
+                        if line:  # Skip empty lines
+                            processed_line = await self.process_line(line, base_url)
+                            yield processed_line + "\n"
+
+                    # If the buffer ended with a newline, the last line is also complete
+                    if decoded_buffer.endswith("\n"):
+                        if lines[-1]:  # Process the last line if it's not empty
+                            processed_line = await self.process_line(lines[-1], base_url)
+                            yield processed_line + "\n"
+                        buffer = b""  # Clear the buffer
+                    else:
+                        # Keep the last incomplete line in the buffer
+                        buffer = lines[-1].encode("utf-8")
+            except UnicodeDecodeError:
+                # If we can't decode the buffer, keep accumulating data
+                continue
+
+        # Process any remaining data in the buffer
+        if buffer:
+            try:
+                # Final attempt to decode any remaining data
+                remaining = buffer.decode("utf-8", errors="replace")
+                if remaining:
+                    processed_line = await self.process_line(remaining, base_url)
+                    yield processed_line
+            except Exception as e:
+                logging.error(f"Error processing final buffer: {e}")
+                # Yield any remaining content with replacement characters
+                yield await self.process_line(buffer.decode("utf-8", errors="replace"), base_url)
+
+    async def process_line(self, line: str, base_url: str) -> str:
+        """
+        Process a single line from the m3u8 content.
+
+        Args:
+            line (str): The line to process.
+            base_url (str): The base URL to resolve relative URLs.
+
+        Returns:
+            str: The processed line.
+        """
+        if "URI=" in line:
+            return await self.process_key_line(line, base_url)
+        elif not line.startswith("#") and line.strip():
+            return await self.proxy_url(line, base_url)
+        else:
+            return line
 
     async def process_key_line(self, line: str, base_url: str) -> str:
         """


### PR DESCRIPTION
Add on-the-fly processing for m3u8 content with streaming support, improving HLS playlist handling. Introduce retry mechanism for HTTP streaming requests and configurable timeout via transport settings. Refactor and optimize URL parsing, error handling, and response generation for better robustness and maintainability.