### PR TITLE
VOD MPDs: Fallback defaults for missing attributes

### DIFF
--- a/mediaflow_proxy/utils/cache_utils.py
+++ b/mediaflow_proxy/utils/cache_utils.py
@@ -325,7 +325,7 @@ async def get_cached_mpd(
         parsed_dict = parse_mpd_dict(mpd_dict, mpd_url, parse_drm, parse_segment_profile_id)
 
         # Cache the original MPD dict
-        await MPD_CACHE.set(mpd_url, json.dumps(mpd_dict).encode(), ttl=parsed_dict["minimumUpdatePeriod"])
+        await MPD_CACHE.set(mpd_url, json.dumps(mpd_dict).encode(), ttl=parsed_dict.get("minimumUpdatePeriod"))
         return parsed_dict
     except DownloadError as error:
         logger.error(f"Error downloading MPD: {error}")

--- a/mediaflow_proxy/utils/mpd_utils.py
+++ b/mediaflow_proxy/utils/mpd_utils.py
@@ -317,7 +317,7 @@ def parse_segment_timeline(parsed_dict: dict, item: dict, profile: dict, source:
     """
     timelines = item["SegmentTimeline"]["S"]
     timelines = timelines if isinstance(timelines, list) else [timelines]
-    period_start = parsed_dict["availabilityStartTime"] + timedelta(seconds=parsed_dict.get("PeriodStart", 0))
+    period_start = parsed_dict.get("availabilityStartTime", datetime.fromtimestamp(0, tz=timezone.utc)) + timedelta(seconds=parsed_dict.get("PeriodStart", 0))
     presentation_time_offset = int(item.get("@presentationTimeOffset", 0))
     start_number = int(item.get("@startNumber", 1))
 


### PR DESCRIPTION
VOD MPDs doesn't have the attributes `minimumUpdatePeriod`, `availabilityStartTime` and `PeriodStart`.

`ttl` is set to None which means the default 1 hour.
`period_start` is set to Unix time 0.

Fixes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of missing data in media manifest processing to prevent potential errors and ensure smoother playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->