### PR TITLE
feat: add UI access control middleware and new configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Set the following environment variables:
 
 - `API_PASSWORD`: Optional. Protects against unauthorized access and API network abuses.
 - `ENABLE_STREAMING_PROGRESS`: Optional. Enable streaming progress logging. Default is `false`.
+- `DISABLE_HOME_PAGE`: Optional. Disables the home page UI. Returns 404 for the root path and direct access to index.html. Default is `false`.
+- `DISABLE_DOCS`: Optional. Disables the API documentation (Swagger UI). Returns 404 for the /docs path. Default is `false`.
+- `DISABLE_SPEEDTEST`: Optional. Disables the speedtest UI. Returns 404 for the /speedtest path and direct access to speedtest.html. Default is `false`.
 
 ### Transport Configuration
 
@@ -168,7 +171,7 @@ MediaFlow Proxy now includes a built-in speed test feature for testing RealDebri
 
 #### Using pip
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > Ensure that you have Python 3.10 or higher installed.
 
 1. Install the package:
@@ -195,7 +198,7 @@ MediaFlow Proxy now includes a built-in speed test feature for testing RealDebri
 
 #### Using git & poetry
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > Ensure that you have Python 3.10 or higher installed.
 
 

--- a/mediaflow_proxy/configs.py
+++ b/mediaflow_proxy/configs.py
@@ -56,6 +56,9 @@ class Settings(BaseSettings):
     log_level: str = "INFO"  # The logging level to use.
     transport_config: TransportConfig = Field(default_factory=TransportConfig)  # Configuration for httpx transport.
     enable_streaming_progress: bool = False  # Whether to enable streaming progress tracking.
+    disable_home_page: bool = False  # Whether to disable the home page UI.
+    disable_docs: bool = False  # Whether to disable the API documentation (Swagger UI).
+    disable_speedtest: bool = False  # Whether to disable the speedtest UI.
 
     user_agent: str = (
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3"  # The user agent to use for HTTP requests.

--- a/mediaflow_proxy/main.py
+++ b/mediaflow_proxy/main.py
@@ -9,6 +9,7 @@ from starlette.responses import RedirectResponse
 from starlette.staticfiles import StaticFiles
 
 from mediaflow_proxy.configs import settings
+from mediaflow_proxy.middleware import UIAccessControlMiddleware
 from mediaflow_proxy.routes import proxy_router, extractor_router, speedtest_router
 from mediaflow_proxy.schemas import GenerateUrlRequest, GenerateMultiUrlRequest, MultiUrlRequestItem
 from mediaflow_proxy.utils.crypto_utils import EncryptionHandler, EncryptionMiddleware
@@ -26,6 +27,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 app.add_middleware(EncryptionMiddleware)
+app.add_middleware(UIAccessControlMiddleware)
 
 
 async def verify_api_key(api_key: str = Security(api_password_query), api_key_alt: str = Security(api_password_header)):

--- a/mediaflow_proxy/middleware.py
+++ b/mediaflow_proxy/middleware.py
@@ -1,0 +1,26 @@
+from fastapi import Request, HTTPException
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from mediaflow_proxy.configs import settings
+
+
+class UIAccessControlMiddleware(BaseHTTPMiddleware):
+    """Middleware that controls access to UI components based on settings."""
+
+    async def dispatch(self, request: Request, call_next):
+        path = request.url.path
+
+        # Block access to home page
+        if settings.disable_home_page and (path == "/" or path == "/index.html"):
+            raise HTTPException(status_code=404, detail="Not Found")
+
+        # Block access to API docs
+        if settings.disable_docs and (path == "/docs" or path == "/redoc" or path.startswith("/openapi")):
+            raise HTTPException(status_code=404, detail="Not Found")
+
+        # Block access to speedtest UI
+        if settings.disable_speedtest and path.startswith("/speedtest"):
+            raise HTTPException(status_code=404, detail="Not Found")
+
+        return await call_next(request)
+


### PR DESCRIPTION
Introduced middleware to manage access to UI components based on new settings. Added options to disable the home page, API documentation, and speedtest UI in the configuration. Updated README to reflect these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added options to disable the home page, API documentation, and speedtest UI via environment variables. When disabled, these endpoints return a 404 error.
- **Documentation**
  - Updated the README to document the new environment variables and corrected callout formatting in installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->