### PR TITLE
feat: add Stremio server proxy support and M3U8 content routing options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Set the following environment variables:
 - `DISABLE_HOME_PAGE`: Optional. Disables the home page UI. Returns 404 for the root path and direct access to index.html. Default is `false`.
 - `DISABLE_DOCS`: Optional. Disables the API documentation (Swagger UI). Returns 404 for the /docs path. Default is `false`.
 - `DISABLE_SPEEDTEST`: Optional. Disables the speedtest UI. Returns 404 for the /speedtest path and direct access to speedtest.html. Default is `false`.
+- `STREMIO_PROXY_URL`: Optional. Stremio server URL for alternative content proxying. Example: `http://127.0.0.1:11470`.
+- `M3U8_CONTENT_ROUTING`: Optional. Routing strategy for M3U8 content URLs: `mediaflow` (default), `stremio`, or `direct`.
 
 ### Transport Configuration
 
@@ -465,6 +467,24 @@ Here's how to utilize MediaFlow Proxy in this scenario:
 2. If MediaFlow Proxy is set up locally:
    - Stremio addons can directly use the client's IP address.
 
+### Using Stremio Server for M3U8 Content Proxy
+
+MediaFlow Proxy supports routing video segments through Stremio server for better performance while keeping playlists through MediaFlow for access control.
+
+#### Configuration
+
+```bash
+# Set Stremio server URL
+STREMIO_PROXY_URL=http://127.0.0.1:11470
+
+# Choose routing strategy
+M3U8_CONTENT_ROUTING=stremio  # or "mediaflow" (default) or "direct"
+```
+
+**Routing Options:**
+- `mediaflow` (default): All content through MediaFlow
+- `stremio`: Video segments through Stremio, playlists through MediaFlow
+- `direct`: Video segments served directly, playlists through MediaFlow
 
 ## Future Development
 

--- a/mediaflow_proxy/configs.py
+++ b/mediaflow_proxy/configs.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Union
+from typing import Dict, Literal, Optional, Union
 
 import httpx
 from pydantic import BaseModel, Field
@@ -59,6 +59,8 @@ class Settings(BaseSettings):
     disable_home_page: bool = False  # Whether to disable the home page UI.
     disable_docs: bool = False  # Whether to disable the API documentation (Swagger UI).
     disable_speedtest: bool = False  # Whether to disable the speedtest UI.
+    stremio_proxy_url: str | None = None  # The Stremio server URL for alternative content proxying.
+    m3u8_content_routing: Literal["mediaflow", "stremio", "direct"] = "mediaflow"  # Routing strategy for M3U8 content URLs: "mediaflow", "stremio", or "direct"
 
     user_agent: str = (
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"  # The user agent to use for HTTP requests.


### PR DESCRIPTION
Enhanced the README with new configuration options for Stremio proxy URL and M3U8 content routing strategies. Updated the Settings class to include these options and implemented a new function to encode Stremio proxy URLs. Modified M3U8Processor to support routing based on the selected strategy, allowing for improved content delivery performance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configurable routing of video segment URLs in M3U8 playlists, allowing segments to be routed through MediaFlow Proxy, a Stremio server, or served directly.
  - Introduced new environment variables to control the routing strategy and specify a Stremio proxy server.
- **Documentation**
  - Updated documentation to explain new configuration options and usage for integrating Stremio server proxying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->