### PR TITLE
Switch from using Debian Buster to Debian Bookworm

### DIFF
--- a/README.md
+++ b/README.md
@@ -720,7 +720,7 @@ Ideal for users who want a reliable, plug-and-play solution without the technica
 4. Go to the "Settings" tab and create a new secret with the name `API_PASSWORD` and set the value to your desired password.
 5. Go to the "Files" tab and create a new file with the name `Dockerfile` and paste the following content. After that, replace `YourUsername/YourRepoName` in the Dockerfile with your username and the name of your fork. Finally, click on "Commit" to save the changes. Remember, your space might get banned if instead of using your fork, you use the main repo.
     ```dockerfile
-    FROM python:3.10-slim-buster
+    FROM python:3.10-slim-bookworm
 
     WORKDIR /app
 


### PR DESCRIPTION
Under installation option 3 (Hugging Face Space Deployment), the dummy Dockerfile provided in step 5 uses Debian Buster, which is deprecated and will cause build errors if used. Consider switching over to using Bookworm to preserve functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Hugging Face Space deployment guide to use the Docker base image python:3.10-slim-bookworm instead of python:3.10-slim-buster.
  * No other content in the snippet changed.
  * Readers following the guide will now build images on the updated Debian base.
  * No changes to app behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->