### PR TITLE
Add FileLions extractor and improve eval_solver

### DIFF
--- a/mediaflow_proxy/extractors/factory.py
+++ b/mediaflow_proxy/extractors/factory.py
@@ -3,6 +3,7 @@ from typing import Dict, Type
 from mediaflow_proxy.extractors.base import BaseExtractor, ExtractorError
 from mediaflow_proxy.extractors.dlhd import DLHDExtractor
 from mediaflow_proxy.extractors.doodstream import DoodStreamExtractor
+from mediaflow_proxy.extractors.filelions import FileLionsExtractor
 from mediaflow_proxy.extractors.livetv import LiveTVExtractor
 from mediaflow_proxy.extractors.maxstream import MaxstreamExtractor
 from mediaflow_proxy.extractors.mixdrop import MixdropExtractor
@@ -19,6 +20,7 @@ class ExtractorFactory:
 
     _extractors: Dict[str, Type[BaseExtractor]] = {
         "Doodstream": DoodStreamExtractor,
+        "FileLions": FileLionsExtractor,
         "Uqload": UqloadExtractor,
         "Mixdrop": MixdropExtractor,
         "Streamtape": StreamtapeExtractor,

--- a/mediaflow_proxy/extractors/fastream.py
+++ b/mediaflow_proxy/extractors/fastream.py
@@ -14,9 +14,9 @@ class FastreamExtractor(BaseExtractor):
 
     async def extract(self, url: str, **kwargs) -> Dict[str, Any]:
         headers  = {'Accept': '*/*', 'Connection': 'keep-alive','Accept-Language': 'en-US,en;q=0.5','Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', 'user-agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:138.0) Gecko/20100101 Firefox/138.0'}
-        pattern = r'file:"(.*?)"'
+        patterns = [r'file:"(.*?)"']
 
-        final_url = await eval_solver(self, url, headers, pattern)
+        final_url = await eval_solver(self, url, headers, patterns)
 
         self.base_headers["referer"] = f'https://{url.replace("https://","").split("/")[0]}/'
         self.base_headers["origin"] = f'https://{url.replace("https://","").split("/")[0]}'

--- a/mediaflow_proxy/extractors/filelions.py
+++ b/mediaflow_proxy/extractors/filelions.py
@@ -1,21 +1,19 @@
-import re
 from typing import Dict, Any
 
 from mediaflow_proxy.extractors.base import BaseExtractor
 from mediaflow_proxy.utils.packed import eval_solver
 
-
-
-
-class SupervideoExtractor(BaseExtractor):
-    """Supervideo URL extractor."""
+class FileLionsExtractor(BaseExtractor):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.mediaflow_endpoint = "hls_manifest_proxy"
-        
+
     async def extract(self, url: str, **kwargs) -> Dict[str, Any]:
-        headers  = {'Accept': '*/*', 'Connection': 'keep-alive', 'User-Agent': 'Mozilla/5.0 (Linux; Android 12) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.71 Mobile Safari/537.36', 'user-agent': 'Mozilla/5.0 (Linux; Android 12) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.71 Mobile Safari/537.36'}
-        patterns = [r'file:"(.*?)"']
+        headers  = {}
+        patterns = [ # See https://github.com/Gujal00/ResolveURL/blob/master/script.module.resolveurl/lib/resolveurl/plugins/filelions.py
+            r'''sources:\s*\[{file:\s*["'](?P<url>[^"']+)''',
+            r'''["']hls[24]["']:\s*["'](?P<url>[^"']+)'''
+        ]
 
         final_url = await eval_solver(self, url, headers, patterns)
 

--- a/mediaflow_proxy/extractors/filelions.py
+++ b/mediaflow_proxy/extractors/filelions.py
@@ -12,7 +12,7 @@ class FileLionsExtractor(BaseExtractor):
         headers  = {}
         patterns = [ # See https://github.com/Gujal00/ResolveURL/blob/master/script.module.resolveurl/lib/resolveurl/plugins/filelions.py
             r'''sources:\s*\[{file:\s*["'](?P<url>[^"']+)''',
-            r'''["']hls[234]["']:\s*["'](?P<url>[^"']+)'''
+            r'''["']hls[24]["']:\s*["'](?P<url>[^"']+)'''
         ]
 
         final_url = await eval_solver(self, url, headers, patterns)

--- a/mediaflow_proxy/extractors/filelions.py
+++ b/mediaflow_proxy/extractors/filelions.py
@@ -12,7 +12,7 @@ class FileLionsExtractor(BaseExtractor):
         headers  = {}
         patterns = [ # See https://github.com/Gujal00/ResolveURL/blob/master/script.module.resolveurl/lib/resolveurl/plugins/filelions.py
             r'''sources:\s*\[{file:\s*["'](?P<url>[^"']+)''',
-            r'''["']hls[24]["']:\s*["'](?P<url>[^"']+)'''
+            r'''["']hls[234]["']:\s*["'](?P<url>[^"']+)'''
         ]
 
         final_url = await eval_solver(self, url, headers, patterns)

--- a/mediaflow_proxy/extractors/mixdrop.py
+++ b/mediaflow_proxy/extractors/mixdrop.py
@@ -15,7 +15,7 @@ class MixdropExtractor(BaseExtractor):
         headers = {"accept-language": "en-US,en;q=0.5"}
         patterns = [r'MDCore.wurl ?= ?"(.*?)"']
 
-        final_url = f"https:{await eval_solver(self, url, headers, patterns)}"
+        final_url = await eval_solver(self, url, headers, patterns)
 
         self.base_headers["referer"] = url
         return {

--- a/mediaflow_proxy/extractors/mixdrop.py
+++ b/mediaflow_proxy/extractors/mixdrop.py
@@ -13,9 +13,9 @@ class MixdropExtractor(BaseExtractor):
             url = url.replace("club", "ps").split("/2")[0]
 
         headers = {"accept-language": "en-US,en;q=0.5"}
-        pattern = r'MDCore.wurl ?= ?"(.*?)"'
+        patterns = [r'MDCore.wurl ?= ?"(.*?)"']
 
-        final_url = f"https:{await eval_solver(self, url, headers, pattern)}"
+        final_url = f"https:{await eval_solver(self, url, headers, patterns)}"
 
         self.base_headers["referer"] = url
         return {

--- a/mediaflow_proxy/schemas.py
+++ b/mediaflow_proxy/schemas.py
@@ -96,7 +96,7 @@ class MPDSegmentParams(GenericParams):
 
 class ExtractorURLParams(GenericParams):
     host: Literal[
-        "Doodstream", "Mixdrop", "Uqload", "Streamtape", "Supervideo", "VixCloud", "Okru", "Maxstream", "LiveTV", "DLHD", "Fastream"
+        "Doodstream", "FileLions", "Mixdrop", "Uqload", "Streamtape", "Supervideo", "VixCloud", "Okru", "Maxstream", "LiveTV", "DLHD", "Fastream"
     ] = Field(..., description="The host to extract the URL from.")
     destination: str = Field(..., description="The URL of the stream.", alias="d")
     redirect_stream: bool = Field(False, description="Whether to redirect to the stream endpoint automatically.")

--- a/mediaflow_proxy/utils/packed.py
+++ b/mediaflow_proxy/utils/packed.py
@@ -143,7 +143,7 @@ class UnpackingError(Exception):
 
 
 
-async def eval_solver(self, url: str, headers, patterns: list[str]) -> str:
+async def eval_solver(self, url: str, headers: dict[str, str] | None, patterns: list[str]) -> str:
     try:
         response = await self._make_request(url, headers=headers)
         soup = BeautifulSoup(response.text, "lxml",parse_only=SoupStrainer("script"))
@@ -154,14 +154,14 @@ async def eval_solver(self, url: str, headers, patterns: list[str]) -> str:
                 for pattern in patterns:
                     match = re.search(pattern, unpacked_code)
                     if match:
-                        m3u8_url = match.group(1)
-                        if m3u8_url.startswith("//"):
-                            m3u8_url = urlparse(url).scheme + ":" + m3u8_url
-                        elif not m3u8_url.startswith("http"):
-                            m3u8_url = urljoin(url, m3u8_url)
+                        extracted_url = match.group(1)
+                        if extracted_url.startswith("//"):
+                            extracted_url = urlparse(url).scheme + ":" + extracted_url
+                        elif not extracted_url.startswith("http"):
+                            extracted_url = urljoin(url, extracted_url)
 
-                        return m3u8_url
+                        return extracted_url
         raise UnpackingError("p.a.c.k.e.r script detected but none of the provided patterns matched.")
     except Exception as e:
-        logger.exception("Eval solver error")
+        logger.exception("Eval solver error for %s", url)
         raise UnpackingError("Error in eval_solver") from e

--- a/mediaflow_proxy/utils/packed.py
+++ b/mediaflow_proxy/utils/packed.py
@@ -14,7 +14,7 @@
 
 import re
 from bs4 import BeautifulSoup, SoupStrainer
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 import logging
 
 
@@ -155,9 +155,9 @@ async def eval_solver(self, url: str, headers, patterns: list[str]) -> str:
                     match = re.search(pattern, unpacked_code)
                     if match:
                         m3u8_url = match.group(1)
-                        if m3u8_url.startswith('//'):
-                            m3u8_url = "https:" + m3u8_url
-                        elif m3u8_url.startswith('/'):
+                        if m3u8_url.startswith("//"):
+                            m3u8_url = urlparse(url).scheme + ":" + m3u8_url
+                        elif not m3u8_url.startswith("http"):
                             m3u8_url = urljoin(url, m3u8_url)
 
                         return m3u8_url

--- a/mediaflow_proxy/utils/packed.py
+++ b/mediaflow_proxy/utils/packed.py
@@ -155,13 +155,11 @@ async def eval_solver(self, url: str, headers: dict[str, str] | None, patterns: 
                     match = re.search(pattern, unpacked_code)
                     if match:
                         extracted_url = match.group(1)
-                        if extracted_url.startswith("//"):
-                            extracted_url = urlparse(url).scheme + ":" + extracted_url
-                        elif not extracted_url.startswith("http"):
+                        if not urlparse(extracted_url).scheme:
                             extracted_url = urljoin(url, extracted_url)
 
                         return extracted_url
-        raise UnpackingError("p.a.c.k.e.r script detected but none of the provided patterns matched.")
+        raise UnpackingError("No p.a.c.k.e.d JS found or no pattern matched.")
     except Exception as e:
         logger.exception("Eval solver error for %s", url)
         raise UnpackingError("Error in eval_solver") from e

--- a/mediaflow_proxy/utils/packed.py
+++ b/mediaflow_proxy/utils/packed.py
@@ -142,7 +142,7 @@ class UnpackingError(Exception):
 
 
 
-async def eval_solver(self, url: str, headers, pattern: str) -> str:
+async def eval_solver(self, url: str, headers, patterns: list[str]) -> str:
     try:
         response = await self._make_request(url, headers=headers)
         soup = BeautifulSoup(response.text, "lxml",parse_only=SoupStrainer("script"))
@@ -150,10 +150,11 @@ async def eval_solver(self, url: str, headers, pattern: str) -> str:
         for i in script_all:
             if detect(i.text):
                 unpacked_code = unpack(i.text)
-                match = re.search(pattern, unpacked_code)
-                if match:
-                    m3u8_url = match.group(1)
-                    return m3u8_url
+                for pattern in patterns:
+                    match = re.search(pattern, unpacked_code)
+                    if match:
+                        m3u8_url = match.group(1)
+                        return m3u8_url
     except Exception as e:
         logger.error("Eval solver error\n",e)
         raise Exception("Error in eval_solver")

--- a/mediaflow_proxy/utils/packed.py
+++ b/mediaflow_proxy/utils/packed.py
@@ -161,6 +161,7 @@ async def eval_solver(self, url: str, headers, patterns: list[str]) -> str:
                             m3u8_url = urljoin(url, m3u8_url)
 
                         return m3u8_url
+        raise UnpackingError("p.a.c.k.e.r script detected but none of the provided patterns matched.")
     except Exception as e:
-        logger.error("Eval solver error\n",e)
-        raise Exception("Error in eval_solver")
+        logger.exception("Eval solver error")
+        raise UnpackingError("Error in eval_solver") from e

--- a/mediaflow_proxy/utils/packed.py
+++ b/mediaflow_proxy/utils/packed.py
@@ -14,6 +14,7 @@
 
 import re
 from bs4 import BeautifulSoup, SoupStrainer
+from urllib.parse import urljoin
 import logging
 
 
@@ -154,6 +155,11 @@ async def eval_solver(self, url: str, headers, patterns: list[str]) -> str:
                     match = re.search(pattern, unpacked_code)
                     if match:
                         m3u8_url = match.group(1)
+                        if m3u8_url.startswith('//'):
+                            m3u8_url = "https:" + m3u8_url
+                        elif m3u8_url.startswith('/'):
+                            m3u8_url = urljoin(url, m3u8_url)
+
                         return m3u8_url
     except Exception as e:
         logger.error("Eval solver error\n",e)


### PR DESCRIPTION
Example URL: https://filelions.to/f/tyn45apubte2

Tested manually via WebStreamr add-on, also did a quick check with a couple of existing extractors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for FileLions links for playback/resolution.

* **Bug Fixes**
  * Improved stream resolution reliability for Fastream, Mixdrop, and Supervideo by matching multiple patterns and removing incorrect URL prefixes.

* **Refactor**
  * Pattern matching now tries multiple patterns, normalizes resolved URLs, and improves unpacking error handling and logging.

* **Chores**
  * Validation updated to recognize FileLions as a valid host.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->