### PR TITLE
Added empty string check in host: or host= pattern

### DIFF
--- a/mediaflow_proxy/extractors/dlhd.py
+++ b/mediaflow_proxy/extractors/dlhd.py
@@ -308,7 +308,10 @@ class DLHDExtractor(BaseExtractor):
                 if matches:
                     host = matches[0]
                     logger.debug(f"Found host with pattern '{pattern}': {host}")
-                    break
+
+                    # if this is a bad match, continue with patterns
+                    if(host != ""):
+                        break
             
             if not host:
                 logger.error("Failed to extract host from iframe content")


### PR DESCRIPTION
For some reason this url pattern fails for me even though it seems to work fine for @nzo66.  Adding this check fixes my issue.  