### PR TITLE
Pass through extractor HTTP errors

### DIFF
--- a/mediaflow_proxy/extractors/base.py
+++ b/mediaflow_proxy/extractors/base.py
@@ -4,7 +4,7 @@ from typing import Dict, Optional, Any
 import httpx
 
 from mediaflow_proxy.configs import settings
-from mediaflow_proxy.utils.http_utils import create_httpx_client
+from mediaflow_proxy.utils.http_utils import create_httpx_client, DownloadError
 
 
 class ExtractorError(Exception):
@@ -39,8 +39,8 @@ class BaseExtractor(ABC):
                 )
                 response.raise_for_status()
                 return response
-        except httpx.HTTPError as e:
-            raise ExtractorError(f"HTTP request failed for URL {url}: {str(e)}")
+        except httpx.HTTPStatusError as e:
+            raise DownloadError(e.response.status_code, f"HTTP error {e.response.status_code} while requesting {url}")
         except Exception as e:
             raise ExtractorError(f"Request failed for URL {url}: {str(e)}")
 

--- a/mediaflow_proxy/routes/extractor.py
+++ b/mediaflow_proxy/routes/extractor.py
@@ -9,6 +9,7 @@ from mediaflow_proxy.extractors.factory import ExtractorFactory
 from mediaflow_proxy.schemas import ExtractorURLParams
 from mediaflow_proxy.utils.cache_utils import get_cached_extractor_result, set_cache_extractor_result
 from mediaflow_proxy.utils.http_utils import (
+    DownloadError,
     encode_mediaflow_proxy_url,
     get_original_scheme,
     ProxyRequestHeaders,
@@ -58,6 +59,9 @@ async def extract_url(
 
         return response
 
+    except DownloadError as e:
+        logger.error(f"Extraction failed: {str(e)}")
+        raise HTTPException(status_code=e.status_code, detail=str(e))
     except ExtractorError as e:
         logger.error(f"Extraction failed: {str(e)}")
         raise HTTPException(status_code=400, detail=str(e))


### PR DESCRIPTION
Makes use of `DownloadError` from http_utils to retain the HTTP status code in extractors, very similar to what `fetch_with_retry()` is doing already. I was wondering if the whole extractor basic request should be switched over to `fetch_with_retry()` from http_utils, but that would be more invasive of course.

Reason for doing this: currently all http errors are converted to 400 which is annyoing. E.g. if an embed URL returns 404, I would expect the proxy to return 404 as well.

E.g. with https://vixsrc.to/movie/37903

before
```sh
→ curl 'https://mediaflow.test/extractor/video?host=VixCloud&api_password=password&d=https%3A%2F%2Fvixsrc.to%2Fmovie%2F37903' -I
HTTP/1.1 400 Bad Request
Server: nginx/1.24.0 (Ubuntu)
Date: Mon, 15 Sep 2025 13:41:02 GMT
Content-Type: application/json
Content-Length: 230
Connection: keep-alive
```

after
```sh
→ curl 'https://mediaflow.test/extractor/video?host=VixCloud&api_password=password&d=https%3A%2F%2Fvixsrc.to%2Fmovie%2F37903' -I
HTTP/1.1 404 Not Found
Server: nginx/1.24.0 (Ubuntu)
Date: Mon, 15 Sep 2025 13:41:41 GMT
Content-Type: application/json
Content-Length: 75
Connection: keep-alive
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - HTTP errors from remote services now return accurate status codes (e.g., 4xx/5xx) instead of a generic error, improving transparency for failed URL extractions.
  - Error messages are clearer and reflect the original cause, aiding troubleshooting.
  - Explicit handling of download failures prevents misclassification under generic extraction errors, leading to more predictable API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->