### PR TITLE
Handle Filemoon 200 Not Found with 404

### DIFF
--- a/mediaflow_proxy/extractors/filemoon.py
+++ b/mediaflow_proxy/extractors/filemoon.py
@@ -2,6 +2,7 @@ import re
 from typing import Dict, Any
 
 from mediaflow_proxy.extractors.base import BaseExtractor, ExtractorError
+from mediaflow_proxy.utils.http_utils import DownloadError
 from mediaflow_proxy.utils.packed import eval_solver
 
 
@@ -12,6 +13,8 @@ class FileMoonExtractor(BaseExtractor):
 
     async def extract(self, url: str, **kwargs) -> Dict[str, Any]:
         response = await self._make_request(url)
+        if "Page not found" in response.text:
+            raise DownloadError(404, "Not Found")
 
         pattern = r"iframe.*?src=[\"'](.*?)[\"']"
         match = re.search(pattern, response.text, re.DOTALL)


### PR DESCRIPTION
e.g. https://filemoon.sx/e/ieolpgynkfad

avoids generic 400 errors

but not a 100% sure if the extractor should be dealing with this tbh
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unavailable FileMoon links by returning a clear “404 Not Found” error when a page is missing, instead of a generic failure. This provides more accurate feedback to users and helps avoid unnecessary retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->