### PR TITLE
&max_res=true

### DIFF
--- a/mediaflow_proxy/schemas.py
+++ b/mediaflow_proxy/schemas.py
@@ -75,6 +75,10 @@ class HLSManifestParams(GenericParams):
         False,
         description="Only proxy the key URL, leaving segment URLs direct.",
     )
+    max_res: bool = Field(
+        False,
+        description="If true, redirects to the highest resolution stream in the manifest.",
+    )
 
 
 class MPDManifestParams(GenericParams):

--- a/mediaflow_proxy/utils/hls_utils.py
+++ b/mediaflow_proxy/utils/hls_utils.py
@@ -1,0 +1,47 @@
+import re
+from typing import List, Dict, Any, Optional, Tuple
+from urllib.parse import urljoin
+
+
+def parse_hls_playlist(playlist_content: str, base_url: Optional[str] = None) -> List[Dict[str, Any]]:
+    """
+    Parses an HLS master playlist to extract stream information.
+
+    Args:
+        playlist_content (str): The content of the M3U8 master playlist.
+        base_url (str, optional): The base URL of the playlist for resolving relative stream URLs. Defaults to None.
+
+    Returns:
+        List[Dict[str, Any]]: A list of dictionaries, each representing a stream variant.
+    """
+    streams = []
+    lines = playlist_content.strip().split('\n')
+    
+    # Regex to capture attributes from #EXT-X-STREAM-INF
+    stream_inf_pattern = re.compile(r'#EXT-X-STREAM-INF:(.*)')
+    
+    for i, line in enumerate(lines):
+        if line.startswith('#EXT-X-STREAM-INF'):
+            stream_info = {}
+            attributes_str = stream_inf_pattern.match(line).group(1)
+            
+            # Parse attributes like BANDWIDTH, RESOLUTION, etc.
+            attributes = re.findall(r'([A-Z-]+)=("([^"]+)"|([^,]+))', attributes_str)
+            for key, _, quoted_val, unquoted_val in attributes:
+                value = quoted_val if quoted_val else unquoted_val
+                if key == 'RESOLUTION':
+                    try:
+                        width, height = map(int, value.split('x'))
+                        stream_info['resolution'] = (width, height)
+                    except ValueError:
+                        stream_info['resolution'] = (0, 0)
+                else:
+                    stream_info[key.lower().replace('-', '_')] = value
+            
+            # The next line should be the stream URL
+            if i + 1 < len(lines) and not lines[i + 1].startswith('#'):
+                stream_url = lines[i + 1].strip()
+                stream_info['url'] = urljoin(base_url, stream_url) if base_url else stream_url
+                streams.append(stream_info)
+                
+    return streams


### PR DESCRIPTION
Added &max_res=true to automatically select the best resolution for an HLS stream. For example, for vixsrc