### PR TITLE
Prefer hls4 link in FileLions extractor

### DIFF
--- a/mediaflow_proxy/extractors/filelions.py
+++ b/mediaflow_proxy/extractors/filelions.py
@@ -12,7 +12,8 @@ class FileLionsExtractor(BaseExtractor):
         headers  = {}
         patterns = [ # See https://github.com/Gujal00/ResolveURL/blob/master/script.module.resolveurl/lib/resolveurl/plugins/filelions.py
             r'''sources:\s*\[{file:\s*["'](?P<url>[^"']+)''',
-            r'''["']hls[24]["']:\s*["'](?P<url>[^"']+)'''
+            r'''["']hls4["']:\s*["'](?P<url>[^"']+)''',
+            r'''["']hls2["']:\s*["'](?P<url>[^"']+)'''
         ]
 
         final_url = await eval_solver(self, url, headers, patterns)


### PR DESCRIPTION
That's what they do themselves too. And hls2 is timing out right now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of HLS streaming URLs to include additional variants, reducing cases where video playback failed to start.
  * Enhanced URL matching increases the success rate of stream resolution without altering the user experience or workflow.
  * More consistent playback across sources that use different HLS identifiers, leading to fewer missing or broken streams.
  * Maintains existing behavior for resolved links while broadening compatibility with providers using alternative HLS formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->