### PR TITLE
Set default user-agent in request headers to fix Torrentio

### DIFF
--- a/mediaflow_proxy/utils/http_utils.py
+++ b/mediaflow_proxy/utils/http_utils.py
@@ -542,6 +542,7 @@ def get_proxy_headers(request: Request) -> ProxyRequestHeaders:
     """
     request_headers = {k: v for k, v in request.headers.items() if k in SUPPORTED_REQUEST_HEADERS}
     request_headers.update({k[2:].lower(): v for k, v in request.query_params.items() if k.startswith("h_")})
+    request_headers.setdefault("user-agent", settings.user_agent)
 
     # Handle common misspelling of referer
     if "referrer" in request_headers:


### PR DESCRIPTION
This PR adds a default User-Agent header to proxy requests in http_utils.py, while preserving per‑request overrides via h_user-agent.
Some addons (e.g., Torrentio used with AIOStreams) return 403 without a browser‑like UA. This makes proxy behavior consistent with extractor requests (which already set settings.user_agent) and avoids failures unless users explicitly override.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP header handling to ensure proper User-Agent header management in proxy requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->