### PR TITLE
Update http_utils.py

### DIFF
--- a/mediaflow_proxy/utils/http_utils.py
+++ b/mediaflow_proxy/utils/http_utils.py
@@ -581,6 +581,8 @@ class EnhancedStreamingResponse(Response):
         self.media_type = self.media_type if media_type is None else media_type
         self.background = background
         self.init_headers(headers)
+        if "content-length" in self.headers:
+            headers.pop("content-length", None)
         self.actual_content_length = 0
 
     @staticmethod


### PR DESCRIPTION
Explicitly removes the Content-Length header so clients do not rely on an incorrect size when the proxy alters the response body during streaming(removing fake bytes). Fixes some occasions on turbovid extractor when those fake bytes are away far that the first chuck(doesn't start instantly after).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP header handling in streaming responses to prevent incorrect content-length header propagation, ensuring responses properly communicate their size to clients.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->