### PR TITLE
Update m3u8_processor.py

### DIFF
--- a/mediaflow_proxy/utils/m3u8_processor.py
+++ b/mediaflow_proxy/utils/m3u8_processor.py
@@ -381,7 +381,7 @@ class M3U8Processor:
                             should_inject = (
                                 self._start_offset_value is not None
                                 and not is_master
-                                and not ("#EXT-X-PLAYLIST-TYPE:VOD" in raw_content)
+                                and "#EXT-X-PLAYLIST-TYPE:VOD" not in raw_content
                                 and (
                                     self._user_provided_start_offset or is_media
                                 )  # User provided OR it's a media playlist


### PR DESCRIPTION
Detect VOD playlist type to prevent playback issues(jumping segments).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VOD playlist detection to prevent incorrect start-offset application and avoid injecting start headers for VOD content, ensuring correct playback behavior unless a start-offset is explicitly provided by the user.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->