### PR TITLE
Add linux/arm/v7 platform support to Docker build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: |
             mhdzumair/mediaflow-proxy:v${{ github.ref_name }}


### PR DESCRIPTION
Make it compatible with linux/arm/v7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added ARM v7 architecture support to Docker builds, extending multi-platform compatibility alongside existing targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->