### PR TITLE
Preserve 206 responses for auto-added stream ranges

### DIFF
--- a/mediaflow_proxy/handlers.py
+++ b/mediaflow_proxy/handlers.py
@@ -417,9 +417,11 @@ async def handle_stream_request(
         # 2. If we auto-added "bytes=0-" range -> preserve 206 for file-like clients
         #    such as Stremio/AIOStreams that rely on partial content for seeking
         # 3. Otherwise preserve the upstream 206 response unchanged
+        remove_set = {h.lower() for h in proxy_headers.remove}
+
         status_code = streamer.response.status
         if status_code == 206:
-            if "content-range" in [h.lower() for h in proxy_headers.remove]:
+            if "content-range" in remove_set:
                 # Explicitly requested to remove content-range
                 status_code = 200
                 # Also remove content-range from response headers if present
@@ -442,7 +444,7 @@ async def handle_stream_request(
             and rate_handler.use_head_cache
             and status_code == 200
             and not auto_added_range
-            and "content-range" not in [h.lower() for h in proxy_headers.remove]
+            and "content-range" not in remove_set
         )
         if should_cache_head:
             await set_cached_head(video_url, dict(streamer.response.headers), status_code)


### PR DESCRIPTION
## Summary
Preserve upstream `206 Partial Content` responses for auto-added `Range: bytes=0-` requests in `handle_stream_request()`.

## Problem
After `2.4.2`, seeking/timeshifting broke in my Stremio + AIOStreams setup when MediaFlow proxy was enabled. Disabling proxy made playback behave normally again.

I traced this to the logic introduced in PR #236 that rewrites upstream `206` responses to `200` when MediaFlow auto-added `bytes=0-`.

## What this changes
This PR keeps the existing explicit `content-range` removal behavior unchanged, but stops rewriting valid upstream `206` responses to `200` in the `auto_added_range` path.

## Why
For file-like playback clients such as Stremio/AIOStreams, preserving the upstream ranged response semantics appears necessary for correct seek/timeshift behavior.

In my testing on `v2.4.5`:
- before this patch: seeking/timeshift broken when proxied through MediaFlow
- after this patch: seeking/timeshift works again

## Reproduction context
- Stremio -> AIOStreams -> MediaFlow proxy
- `2.4.2` works
- `2.4.3+` breaks seeking/timeshift
- local patch on `v2.4.5` restores expected behavior

## AI disclosure
This patch and PR text were prepared with AI assistance, then manually tested against a live local reproduction before opening.

Closes #248


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined handling of 206 Partial Content with three-way logic:
    - Preserve upstream 206 for file-like clients when an auto-added range is present.
    - Convert 206 to 200 only when Content-Range removal is explicitly requested.
    - Leave upstream 206 unchanged otherwise.
  * Fixed header and content-length behavior when ranges are removed.
  * Adjusted HEAD caching to cache only plain 200 metadata and skip certain range cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->