### PR TITLE
Use PORT ENV var instead of hardcoded 8888 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,4 +78,4 @@ ENV PATH="/mediaflow_proxy/.venv/bin:$PATH"
 EXPOSE 8888
 
 # Run the application with Gunicorn (use python -m to avoid venv path issues)
-CMD ["sh", "-c", "exec python -m gunicorn mediaflow_proxy.main:app -w 4 -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:8888 --timeout 120 --max-requests 500 --max-requests-jitter 200 --access-logfile - --error-logfile - --log-level info --forwarded-allow-ips \"${FORWARDED_ALLOW_IPS:-127.0.0.1}\""]
+CMD ["sh", "-c", "exec python -m gunicorn mediaflow_proxy.main:app -w 4 -k uvicorn.workers.UvicornWorker --bind 0.0.0.0:${PORT} --timeout 120 --max-requests 500 --max-requests-jitter 200 --access-logfile - --error-logfile - --log-level info --forwarded-allow-ips \"${FORWARDED_ALLOW_IPS:-127.0.0.1}\""]


### PR DESCRIPTION
I would like to run MFP inside a [Gluetun](https://github.com/qdm12/gluetun) existing nework, which is already exposing port 8888 for a built-in http proxy. A solution is to allow the MFP container to run on a custom port: removing the hardcoded 8888 in Gunicorn command and substitute it with the ENV var PORT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application configuration to support dynamic port binding via environment variables, enabling greater deployment flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->