### PR TITLE
Refactor VixCloudExtractor and add ensure_m3u8 function

### DIFF
--- a/mediaflow_proxy/extractors/vixcloud.py
+++ b/mediaflow_proxy/extractors/vixcloud.py
@@ -1,70 +1,111 @@
 import json
 import re
-from typing import Dict, Any
+from typing import Dict, Any, Optional
+from urllib.parse import urlparse, urlunparse
 
-from bs4 import BeautifulSoup, SoupStrainer
+from bs4 import BeautifulSoup
 
 from mediaflow_proxy.extractors.base import BaseExtractor, ExtractorError
 
 
-class VixCloudExtractor(BaseExtractor):
-    """VixCloud URL extractor."""
+def ensure_m3u8(url: str) -> str:
+    """Ensure HLS playlist ends in .m3u8 if it's a playlist directory."""
+    try:
+        parsed = urlparse(url)
+        path_parts = parsed.path.split("/")
+        if "playlist" in path_parts:
+            idx = path_parts.index("playlist")
+            if idx < len(path_parts) - 1:
+                filename = path_parts[idx + 1]
+                if filename and "." not in filename:
+                    path_parts[idx + 1] = f"{filename}.m3u8"
+                    new_path = "/".join(path_parts)
+                    return urlunparse(parsed._replace(path=new_path))
+        return url
+    except Exception:
+        return url
+
+
+class VixBaseExtractor(BaseExtractor):
+    """Base logic for Vix-style extractors."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.mediaflow_endpoint = "hls_manifest_proxy"
 
+    async def _extract_from_html(self, html: str, url: str) -> Dict[str, Any]:
+        soup = BeautifulSoup(html, "lxml")
+        scripts = soup.find_all("script")
+        target_script = None
+
+        for s in scripts:
+            if s.string and "'token':" in s.string and "'expires':" in s.string:
+                target_script = s.string
+                break
+
+        if not target_script:
+            raise ExtractorError("Player script not found")
+
+        try:
+            # Multi-mode regex for ' or "
+            token = re.search(r"['\"]token['\"]:\s*['\"]([^'\"]+)['\"]", target_script).group(1)
+            expires = re.search(r"['\"]expires['\"]:\s*['\"]([^'\"]+)['\"]", target_script).group(1)
+            server_url = re.search(r"url:\s*['\"]([^'\"]+)['\"]", target_script).group(1)
+        except (AttributeError, IndexError):
+            raise ExtractorError("Failed to parse token, expires, or url")
+
+        # Fix ?b:1 typo
+        server_url = server_url.replace("?b:1", "?b=1")
+
+        sep = "&" if "?" in server_url else "?"
+        final_url = f"{server_url}{sep}token={token}&expires={expires}&h=1"
+        final_url = ensure_m3u8(final_url)
+
+        self.base_headers["referer"] = url
+        return {
+            "destination_url": final_url,
+            "request_headers": self.base_headers,
+            "mediaflow_endpoint": self.mediaflow_endpoint,
+        }
+
+
+class VixCloudExtractor(VixBaseExtractor):
+    """VixCloud URL extractor."""
+
     async def version(self, site_url: str) -> str:
-        """Get version of VixCloud Parent Site."""
         base_url = f"{site_url}/request-a-title"
         response = await self._make_request(
             base_url,
-            headers={
-                "Referer": f"{site_url}/",
-                "Origin": f"{site_url}",
-            },
+            headers={"Referer": f"{site_url}/", "Origin": site_url},
         )
-        if response.status != 200:
-            raise ExtractorError("Outdated Url")
-        # Soup the response
-        soup = BeautifulSoup(response.text, "lxml", parse_only=SoupStrainer("div", {"id": "app"}))
-        if soup:
-            # Extract version
-            try:
-                data = json.loads(soup.find("div", {"id": "app"}).get("data-page"))
-                return data["version"]
-            except (KeyError, json.JSONDecodeError, AttributeError) as e:
-                raise ExtractorError(f"Failed to parse version: {e}")
+        try:
+            soup = BeautifulSoup(response.text, "lxml")
+            app_div = soup.find("div", {"id": "app"})
+            data = json.loads(app_div.get("data-page"))
+            return data["version"]
+        except Exception as e:
+            raise ExtractorError(f"Version fetch fail: {e}")
 
     async def extract(self, url: str, **kwargs) -> Dict[str, Any]:
-        """Extract Vixcloud URL."""
+        headers = {}
         if "iframe" in url:
             site_url = url.split("/iframe")[0]
-            version = await self.version(site_url)
-            response = await self._make_request(url, headers={"x-inertia": "true", "x-inertia-version": version})
-            soup = BeautifulSoup(response.text, "lxml", parse_only=SoupStrainer("iframe"))
-            iframe = soup.find("iframe").get("src")
-            response = await self._make_request(iframe, headers={"x-inertia": "true", "x-inertia-version": version})
-        elif "movie" in url or "tv" in url:
-            response = await self._make_request(url)
+            v = await self.version(site_url)
+            headers.update({"x-inertia": "true", "x-inertia-version": v})
 
-        if response.status != 200:
-            raise ExtractorError("Failed to extract URL components, Invalid Request")
-        soup = BeautifulSoup(response.text, "lxml", parse_only=SoupStrainer("body"))
-        if soup:
-            script = soup.find("body").find("script").text
-            token = re.search(r"'token':\s*'(\w+)'", script).group(1)
-            expires = re.search(r"'expires':\s*'(\d+)'", script).group(1)
-            server_url = re.search(r"url:\s*'([^']+)'", script).group(1)
-            if "?b=1" in server_url:
-                final_url = f"{server_url}&token={token}&expires={expires}"
-            else:
-                final_url = f"{server_url}?token={token}&expires={expires}"
-            if "window.canPlayFHD = true" in script:
-                final_url += "&h=1"
-            self.base_headers["referer"] = url
-            return {
-                "destination_url": final_url,
-                "request_headers": self.base_headers,
-                "mediaflow_endpoint": self.mediaflow_endpoint,
-            }
+        response = await self._make_request(url, headers=headers)
+        return await self._extract_from_html(response.text, url)
+
+
+class VixSrcExtractor(VixBaseExtractor):
+    """VixSrc URL extractor."""
+
+    async def extract(self, url: str, **kwargs) -> Dict[str, Any]:
+        response = await self._make_request(
+            url,
+            headers={
+                "Referer": url,
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+            },
+        )
+        return await self._extract_from_html(response.text, url)


### PR DESCRIPTION
PR: Fix VixCloud & Add VixSrc Extractors
Summary
Improved Vix-based extraction logic. Fixed VixCloud bugs and added VixSrc support.

Key Changes
VixSrcExtractor: Added support for movie and TV URLs. VixCloudExtractor: Fixed Inertia versioning and iframe extraction. VixBaseExtractor: Shared logic for player script parsing. Support both ' and " quotes in regex.
Search all <script> tags for player data.
Handle ?b:1 $\rightarrow$ ?b=1 typo in source URLs. Helper ensure_m3u8: Ensure HLS playlist URLs end in .m3u8 for player compatibility. Headers: Added missing Referer and User-Agent headers required by providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new media source.

* **Bug Fixes**
  * Improved playlist URL compatibility by ensuring proper file extension handling.
  * Enhanced error handling with more informative diagnostic messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->