### PR TITLE
Fix for vixcloud

### DIFF
--- a/mediaflow_proxy/extractors/vixcloud.py
+++ b/mediaflow_proxy/extractors/vixcloud.py
@@ -46,7 +46,8 @@ class VixCloudExtractor(BaseExtractor):
             iframe = soup.find("iframe").get("src")
             response = await self._make_request(iframe, headers={"x-inertia": "true", "x-inertia-version": version})
         elif "movie" in url or "tv" in url:
-            site_url = (url.split('/movie') or url.split('/tv'))[0]
+            marker = "/movie" if "/movie" in url else "/tv"
+            site_url = (url.split(marker))[0]
             parts = url.split(site_url)
             headers = {
                 "Referer": f"{site_url}/",

--- a/mediaflow_proxy/extractors/vixcloud.py
+++ b/mediaflow_proxy/extractors/vixcloud.py
@@ -46,7 +46,16 @@ class VixCloudExtractor(BaseExtractor):
             iframe = soup.find("iframe").get("src")
             response = await self._make_request(iframe, headers={"x-inertia": "true", "x-inertia-version": version})
         elif "movie" in url or "tv" in url:
-            response = await self._make_request(url)
+            site_url = (url.split('/movie') or url.split('/tv'))[0]
+            parts = url.split(site_url)
+            headers = {
+                "Referer": f"{site_url}/",
+                "Origin": f"{site_url}",
+            }
+
+            response = await self._make_request(site_url + '/api' + parts[1])
+
+            response = await self._make_request(site_url + '/' + response.json()['src'],headers=headers)
 
         if response.status != 200:
             raise ExtractorError("Failed to extract URL components, Invalid Request")


### PR DESCRIPTION
The site added an extra layer of protection. This commit bypasses it. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Extraction for movie and TV content now reliably retrieves sources using improved header handling and a two-step API fetch, reducing failures and improving playback availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->