### PR TITLE
docs(readme): add ElfHosted as managed deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ MediaFlow Proxy is a streaming proxy for HTTP(S), HLS (M3U8), and MPEG-DASH—in
 docker run -p 8888:8888 -e API_PASSWORD=your_password mhdzumair/mediaflow-proxy
 ```
 
+> Prefer not to self-host? A managed MediaFlow Proxy instance is available via [ElfHosted](https://store.elfhosted.com/product/mediaflow-proxy-2x4k-booster/?utm_source=github&utm_medium=readme&utm_campaign=mediaflow-proxy-readme), bundled with debrid and Stremio addons in their streaming personal-stacks ($1, 7-day trial).
+
 ## Highlights
 
 - DASH (ClearKey) to HLS, HLS manipulation, generic HTTP(S) proxy with custom headers  


### PR DESCRIPTION
Hi mhdzumair,

funkypenguin from ElfHosted here — quick PR to make the managed MediaFlow Proxy option discoverable for users who land on this README looking for a non-self-hosted path. We host MediaFlow Proxy as part of our streaming personal-stacks (alongside debrid + Stremio addons), and you can verify our track record on the [open-source projects we support](https://docs.elfhosted.com/sponsorship/).

Kept this minimal — a two-line blockquote in the Quick start section with a UTM tag for our internal traffic attribution. Happy to move this anywhere or trim it further to fit your README style — let me know what works for you. Thanks for building MediaFlow Proxy!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quick start section with information about a managed MediaFlow Proxy hosting solution, including trial availability and bundled addon support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->