### PR TITLE
docs(readme): add ElfHosted as managed deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ MediaFlow Proxy is a streaming proxy for HTTP(S), HLS (M3U8), and MPEG-DASH—in
 docker run -p 8888:8888 -e API_PASSWORD=your_password mhdzumair/mediaflow-proxy
 ```
 
+> Prefer not to self-host? A managed MediaFlow Proxy instance is available via [ElfHosted](https://store.elfhosted.com/product/mediaflow-proxy-2x4k-booster/?utm_source=github&utm_medium=readme&utm_campaign=mediaflow-proxy-readme), bundled with debrid and Stremio addons in their streaming personal-stacks (7-day trial).
+
 ## Highlights
 
 - DASH (ClearKey) to HLS, HLS manipulation, generic HTTP(S) proxy with custom headers  

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -107,7 +107,7 @@
 For a hassle-free, high-performance deployment of MediaFlow Proxy, consider the premium hosted service through ElfHosted.
 
 To purchase:
-1. Visit [https://store.elfhosted.com/product/mediaflow-proxy](https://store.elfhosted.com/product/mediaflow-proxy)
+1. Visit the [ElfHosted MediaFlow Proxy product page](https://store.elfhosted.com/product/mediaflow-proxy-2x4k-booster/?utm_source=github&utm_medium=docs&utm_campaign=mediaflow-proxy-docs)
 2. Follow ElfHosted's setup instructions
 
 Benefits:


### PR DESCRIPTION
Just a quick reference to the ElfHosted instance, UTM-tagged for our own internal metrics :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an informational note about a managed hosting option (ElfHosted), its included addons and a 7-day trial.
  * Updated the ElfHosted purchase link to point to the new product page with tracking parameters for referral context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->