### PR TITLE
Allows selecting the audio language in the MPD manifest proxy.

### DIFF
--- a/docs/usage/examples.md
+++ b/docs/usage/examples.md
@@ -54,6 +54,13 @@ mpv "http://localhost:8888/proxy/hls/manifest.m3u8?d=https://devstreaming-cdn.ap
 mpv "http://localhost:8888/proxy/hls/manifest.m3u8?d=https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8&max_res=true&api_password=your_password"
 ```
 
+### DASH Stream with Audio Selection
+
+```bash
+# Select specific audio (es)
+mpv "http://localhost:8888/proxy/mpd/manifest.m3u8?d=https://example.com/manifest.mpd&audio_lang=es&api_password=your_password"
+```
+
 ### HLS/DASH Stream with Segment Skipping (Intro/Outro Skip)
 
 ```bash

--- a/docs/usage/url-params-and-encoding.md
+++ b/docs/usage/url-params-and-encoding.md
@@ -14,6 +14,12 @@ Select a specific resolution stream instead of the highest or default.
 - **Effect:** Selects the stream matching the specified resolution. Falls back to the closest lower resolution if exact match is not found.  
 - **Supported Endpoints:** `/proxy/hls/manifest.m3u8`, `/proxy/mpd/manifest.m3u8`
 
+**`&audio_lang=es`**  
+Select a specific audio language (BCP 47 tag, e.g., 'en', 'es', 'es-AR'). Defaults to 'en'.
+- **Usage:** Add `&audio_lang=es` (or `pt`, `es-AR`, etc.) to the proxy URL  
+- **Effect:** Selects the audio matching the specified language. Falls back to the highest-bandwidth audio if exact match not found. 
+- **Supported Endpoints:** `/proxy/mpd/manifest.m3u8`
+
 **`&no_proxy=true`**  
 Disables the proxy for the current destination, performing a direct request.  
 - **Usage:** Add `&no_proxy=true` to the proxy URL  

--- a/mediaflow_proxy/handlers.py
+++ b/mediaflow_proxy/handlers.py
@@ -822,7 +822,7 @@ async def get_manifest(
     if drm_info and not drm_info.get("isDrmProtected"):
         # For non-DRM protected MPD, we still create an HLS manifest
         return await process_manifest(
-            request, mpd_dict, proxy_headers, None, None, manifest_params.resolution, skip_segments
+            request, mpd_dict, proxy_headers, None, None, manifest_params.resolution, skip_segments, manifest_params.audio_lang
         )
 
     # Support combined kid:key,kid:key format passed as a single key= param
@@ -838,7 +838,7 @@ async def get_manifest(
     key = _normalize_drm_key_value(key)
 
     return await process_manifest(
-        request, mpd_dict, proxy_headers, key_id, key, manifest_params.resolution, skip_segments
+        request, mpd_dict, proxy_headers, key_id, key, manifest_params.resolution, skip_segments, manifest_params.audio_lang
     )
 
 

--- a/mediaflow_proxy/mpd_processor.py
+++ b/mediaflow_proxy/mpd_processor.py
@@ -120,6 +120,7 @@ async def process_manifest(
     key: str = None,
     resolution: str = None,
     skip_segments: list = None,
+    audio_lang: str = "en"
 ) -> Response:
     """
     Processes the MPD manifest and converts it to an HLS manifest.
@@ -132,11 +133,13 @@ async def process_manifest(
         key (str, optional): The DRM key. Defaults to None.
         resolution (str, optional): Target resolution (e.g., '1080p', '720p'). Defaults to None.
         skip_segments (list, optional): List of time segments to skip. Each item should have 'start' and 'end' keys.
+        audio_lang (str, optional): Select a specific audio language (BCP 47 tag, e.g., 'en', 'es', 'es-AR').
+            Falls back to the highest-bandwidth audio if exact match not found. Defaults to 'en'.
 
     Returns:
         Response: The HLS manifest as an HTTP response.
     """
-    hls_content = build_hls(mpd_dict, request, key_id, key, resolution, skip_segments)
+    hls_content = build_hls(mpd_dict, request, key_id, key, resolution, skip_segments, audio_lang)
 
     # Start DASH pre-buffering in background if enabled
     if settings.enable_dash_prebuffer:
@@ -391,6 +394,7 @@ def build_hls(
     key: str = None,
     resolution: str = None,
     skip_segments: list = None,
+    audio_lang: str = "en"
 ) -> str:
     """
     Builds an HLS manifest from the MPD manifest.
@@ -402,6 +406,8 @@ def build_hls(
         key (str, optional): The DRM key. Defaults to None.
         resolution (str, optional): Target resolution (e.g., '1080p', '720p'). Defaults to None.
         skip_segments (list, optional): List of time segments to skip. Each item should have 'start' and 'end' keys.
+        audio_lang (str, optional): Select a specific audio language (BCP 47 tag, e.g., 'en', 'es', 'es-AR').
+            Falls back to the highest-bandwidth audio if exact match not found. Defaults to 'en'.
 
     Returns:
         str: The HLS manifest as a string.
@@ -479,12 +485,12 @@ def build_hls(
             deduped = height_deduped[:MAX_VIDEO_VARIANTS]
         video_profiles = {p["id"]: (p, url) for p, url in deduped}
 
-    # Determine the default audio (English preferred, else highest bandwidth).
+    # Determine the default audio (audio_lang preferred, else highest bandwidth).
     default_audio_id = None
     if audio_profiles:
         all_audio = list(audio_profiles.values())
-        en_audio = [(p, u) for p, u in all_audio if (p.get("lang") or "").startswith("en")]
-        default_profile, _ = max(en_audio or all_audio, key=lambda pu: pu[0].get("bandwidth", 0))
+        default_audio = [(p, u) for p, u in all_audio if (p.get("lang") or "").startswith(audio_lang)]
+        default_profile, _ = max(default_audio or all_audio, key=lambda pu: pu[0].get("bandwidth", 0))
         default_audio_id = default_profile["id"]
 
     # Audio tracks: one entry per unique language, capped at MAX_AUDIO_TRACKS.

--- a/mediaflow_proxy/schemas.py
+++ b/mediaflow_proxy/schemas.py
@@ -207,6 +207,13 @@ class MPDManifestParams(GenericParams):
         None,
         description="Override global REMUX_TO_TS setting per-request. true = force TS remuxing, false = force fMP4 passthrough, omit = use server default.",
     )
+    audio_lang: Optional[str] = Field(
+        "en",
+        description=(
+            "Select a specific audio language (BCP 47 tag, e.g., 'en', 'es', 'es-AR'). "
+            "Falls back to the highest-bandwidth audio if exact match not found. Defaults to 'en'."
+        ),
+    )
 
     @field_validator("resolution", mode="before")
     @classmethod

--- a/mediaflow_proxy/static/url_generator.html
+++ b/mediaflow_proxy/static/url_generator.html
@@ -371,6 +371,14 @@
                         </select>
                         <p class="text-xs text-gray-500 dark:text-gray-400 mt-2">Select specific resolution (falls back to closest lower if not available)</p>
                     </div>
+
+                    <!-- Audio Language -->
+                    <div class="bg-gray-50 dark:bg-gray-700/30 rounded-xl p-4 border border-gray-200 dark:border-gray-600">
+                        <h4 class="text-sm font-semibold text-gray-700 dark:text-gray-200 mb-3">Audio</h4>
+                        <input type="text" id="mpd-audio-lang" placeholder="en (BCP 47 language tag)"
+                            class="input-field w-full px-4 py-3 rounded-xl border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:outline-none focus:border-indigo-500 text-sm">
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mt-2">Set audio language (English by default, else highest bandwidth)</p>
+                    </div>
                     
                     <!-- Skip Segments Section -->
                     <div class="bg-gray-50 dark:bg-gray-700/30 rounded-xl p-4 border border-gray-200 dark:border-gray-600">
@@ -2226,6 +2234,10 @@
                 const resolution = document.getElementById('mpd-resolution').value;
                 if (resolution) params.append('resolution', resolution);
                 
+                // Audio language
+                const audioLang = document.getElementById('mpd-audio-lang').value.trim();
+                if (audioLang) params.append('audio_lang', audioLang);
+
                 // Skip segments
                 const skipSegments = document.getElementById('mpd-skip-segments').value.trim();
                 if (skipSegments) params.append('skip', skipSegments);


### PR DESCRIPTION
This change was introduced to avoid the need for users to repeatedly select their preferred audio track in the player. This is especially useful when English is not the users' primary language.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio language selection for DASH manifests using BCP 47 language tags with automatic fallback to highest-bandwidth audio when exact match unavailable.
  * Added audio language input field to the URL generator tool.

* **Documentation**
  * Added "DASH Stream with Audio Selection" example demonstrating language selection.
  * Documented the new audio language parameter with default behavior and supported endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->